### PR TITLE
Use the right reversed elementary scheme

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -2,4 +2,4 @@ install (FILES cerbere.desktop DESTINATION share/applications)
 
 # GSettings schema
 include(GSettings)
-add_schema("org.pantheon.cerbere.gschema.xml")
+add_schema("io.elementary.cerbere.gschema.xml")

--- a/data/io.elementary.cerbere.gschema.xml
+++ b/data/io.elementary.cerbere.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-    <schema path="/org/pantheon/desktop/cerbere/" id="org.pantheon.desktop.cerbere" gettext-domain="cerbere">
+    <schema path="/io/elementary/desktop/cerbere/" id="io.elementary.desktop.cerbere" gettext-domain="cerbere">
         <key type="as" name="monitored-processes">
             <default>['wingpanel','plank']</default>
             <summary>List of monitored components</summary>

--- a/src/Cerbere.vala
+++ b/src/Cerbere.vala
@@ -32,7 +32,7 @@ public class Cerbere.App : Application {
     private SessionManager.Client sm_client;
 
     construct {
-        application_id = "org.pantheon.cerbere";
+        application_id = "io.elementary.cerbere";
         flags = ApplicationFlags.IS_SERVICE;
     }
 

--- a/src/SettingsManager.vala
+++ b/src/SettingsManager.vala
@@ -24,7 +24,7 @@ public class Cerbere.SettingsManager : Object {
 
     public signal void process_list_changed (string[] new_values);
 
-    static const string SETTINGS_PATH = "org.pantheon.desktop.cerbere";
+    static const string SETTINGS_PATH = "io.elementary.desktop.cerbere";
 
     static const string MAX_CRASHES_KEY = "max-crashes";
     static const string CRASH_TIME_INTERVAL_KEY = "crash-time-interval";


### PR DESCRIPTION
Fixes #3 Changed the scheme from `org.pantheon` to `io.elementary` and the paths from `org/pantheon` to `io/elementary`.