### PR TITLE
Handle SIGTERM for clean shutdown

### DIFF
--- a/src/Cerbere.vala
+++ b/src/Cerbere.vala
@@ -68,6 +68,8 @@ public class Cerbere.App : Application {
         if (sm_client != null) {
             // The session manager may ask us to quit the service, and so we do.
             sm_client.stop_service.connect (quit_service);
+            // Cleanly shutdown when receiving SIGTERM.
+            Posix.signal (Posix.Signal.TERM, handle_sigterm);
         }
     }
 
@@ -81,6 +83,11 @@ public class Cerbere.App : Application {
 
     private void quit_service () {
         message ("Closing Cerbere as requested by SessionManager");
+        release ();
+    }
+
+    private void handle_sigterm () {
+        message ("Closing Cerbere as requested via SIGTERM");
         release ();
     }
 


### PR DESCRIPTION
Fixes #6.

Prior to this change, a DBus signal from the SessionManager is the only
way for Cerbere to initiate shutdown. If the connection to DBus is
lost, Cerbere will keep running until externally killed (e.g. by
systemd at shutdown time after its configured timeout).

Since systemd sends SIGTERM to running processes in user sessions
before resorting to SIGHUP, we can handle it much the same way as if
the SessionManager was asking Cerbere to exit and behave correctly.