### PR TITLE
Remove wingpanel autostart from defaults

### DIFF
--- a/data/io.elementary.cerbere.gschema.xml
+++ b/data/io.elementary.cerbere.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist>
     <schema path="/io/elementary/desktop/cerbere/" id="io.elementary.desktop.cerbere">
         <key type="as" name="monitored-processes">
-            <default>['wingpanel','plank']</default>
+            <default>['plank']</default>
             <summary>List of monitored components</summary>
             <description>These applications will be launched and watched by Cerbere, and autorestarted automagically in case they exit</description>
         </key>


### PR DESCRIPTION
It autostarts itself using `gnome-session` now.