### PR TITLE
remove plank from autostart in cerbere

### DIFF
--- a/data/io.elementary.cerbere.gschema.xml
+++ b/data/io.elementary.cerbere.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist>
     <schema path="/io/elementary/desktop/cerbere/" id="io.elementary.desktop.cerbere">
         <key type="as" name="monitored-processes">
-            <default>['plank']</default>
+            <default>[]</default>
             <summary>List of monitored components</summary>
             <description>These applications will be launched and watched by Cerbere, and autorestarted automagically in case they exit</description>
         </key>


### PR DESCRIPTION
Let plank autostart itself via `gnome-session`. 

This is blocked until the [dock project can autostart via `gnome-session`](https://github.com/elementary/dock/pull/14).